### PR TITLE
Fix Compile errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.linfoot</groupId>
     <artifactId>DynDeath</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,10 @@
         </plugins>
     </build>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <repositories>
         <repository>
             <id>spigot-repo</id>

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
+            <id>dynmap-repo</id>
+            <url>https://repo.mikeprimm.com/</url>
         </repository>
     </repositories>
 
@@ -39,9 +39,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.webbukkit</groupId>
+            <groupId>us.dynmap</groupId>
             <artifactId>dynmap-api</artifactId>
-            <version>2.5</version>
+            <version>3.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: DynDeath
-version: 1.0.0
+version: 1.0.1
 main: dev.linfoot.dyndeath.DynDeath
 api-version: 1.16
 author: "Connor Linfoot"


### PR DESCRIPTION
Updates the dynmap repo, provides a version for the maven-compiler and provides an encoder. Updating the dynmap repo is necessary for the plugin to compile as maven 3.8.1 blocks http repositories by default, and dynmap-api v2.5 uses an http repository.